### PR TITLE
feat: Integrate ThemeToggle component into Navbar with improved styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { BrowserRouter, Route, Routes, useLocation } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-// import { Box } from "@primer/react";
 import styled, { ThemeProvider } from "styled-components";
 import useLocalState from "use-local-storage-state";
 import { Toaster } from "react-hot-toast";
@@ -9,7 +8,6 @@ import Footer from "./components/Common/Footer/Footer";
 import Navbar from "./components/Common/Navbar/Navbar";
 import HomePage from "./pages/HomePage/HomePage";
 import { routes } from "./routes/AppRoutes";
-// import { ThemeToggle } from "./components/ui/ThemeToggle";
 import { pageTransition } from "./lib/animations";
 import { TOAST_CONFIG } from "./lib/constants";
 // @ts-expect-error - JS module without types

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Route, Routes, useLocation } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Box } from "@primer/react";
+// import { Box } from "@primer/react";
 import styled, { ThemeProvider } from "styled-components";
 import useLocalState from "use-local-storage-state";
 import { Toaster } from "react-hot-toast";
@@ -9,7 +9,7 @@ import Footer from "./components/Common/Footer/Footer";
 import Navbar from "./components/Common/Navbar/Navbar";
 import HomePage from "./pages/HomePage/HomePage";
 import { routes } from "./routes/AppRoutes";
-import { ThemeToggle } from "./components/ui/ThemeToggle";
+// import { ThemeToggle } from "./components/ui/ThemeToggle";
 import { pageTransition } from "./lib/animations";
 import { TOAST_CONFIG } from "./lib/constants";
 // @ts-expect-error - JS module without types
@@ -91,17 +91,7 @@ function App() {
             }}
           />
           <StyledApp>
-            <Navbar />
-            <Box
-              sx={{
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-                py: 3,
-              }}
-            >
-              <ThemeToggle theme={theme} onToggle={themeToggler} />
-            </Box>
+            <Navbar theme={theme} onToggle={themeToggler} />
             <BrowserRouter>
               <AnimatedRoutes />
             </BrowserRouter>
@@ -114,3 +104,4 @@ function App() {
 }
 
 export default App;
+

--- a/src/components/Common/Navbar/Navbar.tsx
+++ b/src/components/Common/Navbar/Navbar.tsx
@@ -7,9 +7,15 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Header } from "@primer/react";
 import { MarkGithubIcon } from "@primer/octicons-react";
+import { ThemeToggle } from "../../ui/ThemeToggle";
 import "../../../scss/_natbar.scss";
 
-function Navbar() {
+interface NavbarProps {
+  theme: string;
+  onToggle: () => void;
+}
+
+function Navbar({ theme, onToggle }: NavbarProps) {
   return (
     <>
       <Header className="sticky-header">
@@ -20,6 +26,9 @@ function Navbar() {
           </Header.Link>
         </Header.Item>
         <Header.Item full />
+        <Header.Item>
+          <ThemeToggle theme={theme} onToggle={onToggle} />
+        </Header.Item>
         <Header.Link href="https://github.com/sliit-foss" target="blank" sx={{ mr: 2 }}>
           <FontAwesomeIcon icon={faGithub} />
         </Header.Link>
@@ -46,3 +55,4 @@ function Navbar() {
 }
 
 export default Navbar;
+

--- a/src/components/ui/ThemeToggle.scss
+++ b/src/components/ui/ThemeToggle.scss
@@ -48,6 +48,7 @@
 
 [data-theme="dark"] {
   .theme-toggle-thumb {
-    color: #fbbf24;
+    color: #1e293b;
+    background: #fbbf24;
   }
 }


### PR DESCRIPTION
I've moved the light/dark mode theme toggle button into the navigation bar at the top of the page. I also improved the colors to make it look better, especially in dark mode.

Changes
Moved the Button: The theme toggle button is now part of the main navigation bar.

Improved Dark Mode Colors: I updated the styling to make the button have better contrast when the dark theme is active.

Cleaned Up Code: I removed some unnecessary wrapper components to make the code simpler.
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/ad1bae8a-3be4-43eb-976c-ed4754034ab6" />
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/25f8ac69-a9df-481f-b3d3-fbfb15ced330" />
